### PR TITLE
fix(emqx_sn_gateway): Fix will message publish

### DIFF
--- a/src/emqx_sn_gateway.erl
+++ b/src/emqx_sn_gateway.erl
@@ -942,14 +942,13 @@ do_publish_will(#state{will_msg = #will_msg{payload = undefined}}) ->
     ok;
 do_publish_will(#state{will_msg = #will_msg{topic = undefined}}) ->
     ok;
-do_publish_will(#state{channel = Channel, will_msg = WillMsg}) ->
+do_publish_will(#state{will_msg = WillMsg, clientid = ClientId}) ->
     #will_msg{qos = QoS, retain = Retain, topic = Topic, payload = Payload} = WillMsg,
     Publish = #mqtt_packet{header   = #mqtt_packet_header{type = ?PUBLISH, dup = false,
                                                           qos = QoS, retain = Retain},
                            variable = #mqtt_packet_publish{topic_name = Topic, packet_id = 1000},
                            payload  = Payload},
-    ClientInfo = emqx_channel:info(clientinfo, Channel),
-    emqx_broker:publish(emqx_packet:to_message(ClientInfo, Publish)),
+    emqx_broker:publish(emqx_packet:to_message(Publish, ClientId)),
     ok.
 
 do_puback(TopicId, MsgId, ReturnCode, _StateName,


### PR DESCRIPTION
noticed this while fixing dialyzer warnings in dev/v5.0 branch in emqx project.

It seems to me that the first argument should be a `#mqtt_packet{}` record.
i.e. the code prior to this change had the arguments in the wrong order.

I am however not quite sure if it should be `clientid` from state,
or something else from the channel info to be used as the second arg.