### PR TITLE
refactor(emqx_sn_gateway): Ensure binary client ID

### DIFF
--- a/src/emqx_sn_gateway.erl
+++ b/src/emqx_sn_gateway.erl
@@ -201,8 +201,7 @@ idle(cast, {incoming, ?SN_PUBLISH_MSG(#mqtt_sn_flags{qos = ?QOS_NEG1,
                         emqx_sn_registry:lookup_topic(Registry, ClientId, TopicId);
                     true  -> <<TopicId:16>>
                 end,
-    Msg = emqx_message:make({?NEG_QOS_CLIENT_ID, State#state.username},
-                            ?QOS_0, TopicName, Data),
+    Msg = emqx_message:make(?NEG_QOS_CLIENT_ID, ?QOS_0, TopicName, Data),
     (TopicName =/= undefined) andalso emqx_broker:publish(Msg),
     ?LOG(debug, "Client id=~p receives a publish with QoS=-1 in idle mode!", [ClientId], State),
     {keep_state_and_data, State#state.idle_timeout};


### PR DESCRIPTION
The `emqx_message:make` API requires first argument to be binary.

Not entirely sure if this tuple client ID has its special use case though.